### PR TITLE
DE6902-profile-menu-break

### DIFF
--- a/src/shared-header/int.json
+++ b/src/shared-header/int.json
@@ -5,7 +5,7 @@
     "okta_client_id": "0oahgpg7elMxVJedi0h7",
     "okta_issuer": "https://crossroads.oktapreview.com/oauth2/default"
   },
-  "promos": "{{{ promos.int}}}",
+  "promos": "{{{ promos.int }}}",
   "nav": [
     {
       "title": "Watch, Listen, Read [Int]",
@@ -15,7 +15,7 @@
         [
           {
             "title": "All Media",
-            "href": "/media",
+            "href": "https://int.crossroads.net/media",
             "top_level": true,
             "automation-id": "sh-all-media"
           }
@@ -24,27 +24,27 @@
         [
           {
             "title": "Articles",
-            "href": "/media/articles",
+            "href": "https://int.crossroads.net/media/articles",
             "automation-id": "sh-articles"
           },
           {
             "title": "Music",
-            "href": "/media/music",
+            "href": "https://int.crossroads.net/media/music",
             "automation-id": "sh-music"
           },
           {
             "title": "Podcasts",
-            "href": "/media/podcasts",
+            "href": "https://int.crossroads.net/media/podcasts",
             "automation-id": "sh-podcasts"
           },
           {
             "title": "Series",
-            "href": "/media/series",
+            "href": "https://int.crossroads.net/media/series",
             "automation-id": "sh-series"
           },
           {
             "title": "Videos",
-            "href": "/media/videos",
+            "href": "https://int.crossroads.net/media/videos",
             "automation-id": "sh-videos"
           }
         ],
@@ -52,27 +52,27 @@
         [
           {
             "title": "Culture",
-            "href": "/media/topics/culture",
+            "href": "https://int.crossroads.net/media/topics/culture",
             "automation-id": "sh-culture"
           },
           {
             "title": "Self",
-            "href": "/media/topics/self",
+            "href": "https://int.crossroads.net/media/topics/self",
             "automation-id": "sh-self"
           },
           {
             "title": "Work",
-            "href": "/media/topics/work",
+            "href": "https://int.crossroads.net/media/topics/work",
             "automation-id": "sh-work"
           },
           {
             "title": "Money",
-            "href": "/media/topics/money",
+            "href": "https://int.crossroads.net/media/topics/money",
             "automation-id": "sh-money"
           },
           {
             "title": "Relationships",
-            "href": "/media/topics/relationships",
+            "href": "https://int.crossroads.net/media/topics/relationships",
             "automation-id": "sh-relationships"
           }
         ]
@@ -86,7 +86,7 @@
         [
           {
             "title": "Ways to get connected",
-            "href": "/get-connected",
+            "href": "https://int.crossroads.net/get-connected",
             "top_level": true,
             "automation-id": "sh-get-connected"
           }
@@ -95,17 +95,17 @@
         [
           {
             "title": "All Groups",
-            "href": "/groups",
+            "href": "https://int.crossroads.net/groups",
             "automation-id": "sh-connect-groups"
           },
           {
             "title": "My Groups",
-            "href": "/groups/search/my",
+            "href": "https://int.crossroads.net/groups/search/my",
             "automation-id": "sh-my-groups"
           },
           {
             "title": "People near me",
-            "href": "/connect/?filters=At%20Home%20Groups%3D&my=0",
+            "href": "https://int.crossroads.net/connect/?filters=At%20Home%20Groups%3D&my=0",
             "automation-id": "sh-connect-people-near-me"
           }
         ],
@@ -113,22 +113,22 @@
         [
           {
             "title": "All Camps",
-            "href": "/camps",
+            "href": "https://int.crossroads.net/camps",
             "automation-id": "sh-camps"
           },
           {
             "title": "Man Camp",
-            "href": "/mancamp",
+            "href": "https://int.crossroads.net/mancamp",
             "automation-id": "sh-camps-man-camp"
           },
           {
             "title": "Woman Camp",
-            "href": "/womancamp",
+            "href": "https://int.crossroads.net/womancamp",
             "automation-id": "sh-camps-woman-camp"
           },
           {
             "title": "Couples Camp",
-            "href": "/couplescamp",
+            "href": "https://int.crossroads.net/couplescamp",
             "automation-id": "sh-camps-couples-camp"
           }
         ],
@@ -136,12 +136,12 @@
         [
           {
             "title": "All Trips",
-            "href": "/reachout/go",
+            "href": "https://int.crossroads.net/reachout/go",
             "automation-id": "sh-trips-all"
           },
           {
             "title": "My Trips",
-            "href": "/trips/mytrips",
+            "href": "https://int.crossroads.net/trips/mytrips",
             "automation-id": "sh-my-trips"
           }
         ],
@@ -149,17 +149,17 @@
         [
           {
             "title": "Volunteer Opportunities",
-            "href": "/volunteer",
+            "href": "https://int.crossroads.net/volunteer",
             "automation-id": "sh-volunteer"
           },
           {
             "title": "Sign up to Volunteer",
-            "href": "/serve-signup",
+            "href": "https://int.crossroads.net/serve-signup",
             "automation-id": "sh-sign-up-to-serve"
           },
           {
             "title": "Community Serving",
-            "href": "/reachout/local",
+            "href": "https://int.crossroads.net/reachout/local",
             "automation-id": "sh-reachout-local"
           }
         ],
@@ -172,7 +172,7 @@
           },
           {
             "title": "Childcare (for events)",
-            "href": "/childcare",
+            "href": "https://int.crossroads.net/childcare",
             "automation-id": "sh-event-childcare"
           }
         ],
@@ -185,12 +185,12 @@
           },
           {
             "title": "Students 6-8th",
-            "href": "/middleschool",
+            "href": "https://int.crossroads.net/middleschool",
             "automation-id": "sh-kids-students-6-8th"
           },
           {
             "title": "Students 9-12th",
-            "href": "/highschool",
+            "href": "https://int.crossroads.net/highschool",
             "automation-id": "sh-kids-students-6-12th"
           }
         ]
@@ -205,13 +205,13 @@
         [
           {
             "title": "All Locations",
-            "href": "/locations",
+            "href": "https://int.crossroads.net/locations",
             "top_level": true,
             "automation-id": "sh-all-locations"
           },
           {
             "title": "Crossroads Anywhere",
-            "href": "/live",
+            "href": "https://int.crossroads.net/live",
             "top_level": true,
             "automation-id": "sh-crossroads-anywhere"
           }
@@ -220,37 +220,37 @@
         [
           {
             "title": "East Side",
-            "href": "/eastside",
+            "href": "https://int.crossroads.net/eastside",
             "automation-id": "sh-location-east-side"
           },
           {
             "title": "Florence",
-            "href": "/florence",
+            "href": "https://int.crossroads.net/florence",
             "automation-id": "sh-location-east-side"
           },
           {
             "title": "Mason",
-            "href": "/mason",
+            "href": "https://int.crossroads.net/mason",
             "automation-id": "sh-location-mason"
           },
           {
             "title": "Oakley",
-            "href": "/oakley",
+            "href": "https://int.crossroads.net/oakley",
             "automation-id": "sh-location-oakely"
           },
           {
             "title": "Oxford",
-            "href": "/oxford",
+            "href": "https://int.crossroads.net/oxford",
             "automation-id": "sh-location-oxford"
           },
           {
             "title": "Uptown",
-            "href": "/uptown",
+            "href": "https://int.crossroads.net/uptown",
             "automation-id": "sh-location-uptown"
           },
           {
             "title": "West Side",
-            "href": "/westside",
+            "href": "https://int.crossroads.net/westside",
             "automation-id": "sh-location-west-side"
           }
         ],
@@ -258,22 +258,22 @@
         [
           {
             "title": "Lexington",
-            "href": "/lexington",
+            "href": "https://int.crossroads.net/lexington",
             "automation-id": "sh-location-lexington"
           },
           {
             "title": "Downtown Lexington",
-            "href": "/downtown",
+            "href": "https://int.crossroads.net/downtown",
             "automation-id": "sh-location-downtown-lexington"
           },
           {
             "title": "Georgetown",
-            "href": "/georgetown",
+            "href": "https://int.crossroads.net/georgetown",
             "automation-id": "sh-location-georgetown"
           },
           {
             "title": "Richmond",
-            "href": "/richmond",
+            "href": "https://int.crossroads.net/richmond",
             "automation-id": "sh-location-richmond"
           }
         ],
@@ -281,12 +281,12 @@
         [
           {
             "title": "Columbus",
-            "href": "/columbus",
+            "href": "https://int.crossroads.net/columbus",
             "automation-id": "sh-location-columbus"
           },
           {
             "title": "Dayton",
-            "href": "/dayton",
+            "href": "https://int.crossroads.net/dayton",
             "automation-id": "sh-location-more-dayton"
           }
         ],
@@ -294,37 +294,37 @@
         [
           {
             "title": "Blackburn Correctional Complex",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-blckburn-correctional-complex"
           },
           {
             "title": "Dayton Correctional Institution",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-dayton-correctional-institution"
           },
           {
             "title": "Lebanon Correctional Institution",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-lebanon-correctional-institution"
           },
           {
             "title": "London Correctional Institution",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-london-correctional-institution"
           },
           {
             "title": "Marion Correctional Institution",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-marion-correctional-institution"
           },
           {
             "title": "Ohio Reformatory for Women",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-ohio-reformatory-for-women"
           },
           {
             "title": "Warren Correctional Institution",
-            "href": "/reachout/local/prison-ministry",
+            "href": "https://int.crossroads.net/reachout/local/prison-ministry",
             "automation-id": "sh-location-warren-correctional-institution"
           }
         ]
@@ -339,12 +339,12 @@
         [
           {
             "title": "Counselors",
-            "href": "/care/counselors/",
+            "href": "https://int.crossroads.net/care/counselors/",
             "automation-id": "sh-support-counselors"
           },
           {
             "title": "Prayer",
-            "href": "/prayer",
+            "href": "https://int.crossroads.net/prayer",
             "automation-id": "sh-support-counselors"
           }
         ],
@@ -352,17 +352,17 @@
         [
           {
             "title": "Baptism",
-            "href": "/baptism",
+            "href": "https://int.crossroads.net/baptism",
             "automation-id": "sh-support-baptism"
           },
           {
             "title": "Weddings",
-            "href": "/care/weddings",
+            "href": "https://int.crossroads.net/care/weddings",
             "automation-id": "sh-support-weddings"
           },
           {
             "title": "Funerals",
-            "href": "/care/funerals",
+            "href": "https://int.crossroads.net/care/funerals",
             "automation-id": "sh-support-funerals"
           }
         ],
@@ -370,22 +370,22 @@
         [
           {
             "title": "Staff Contacts",
-            "href": "/staffcontacts",
+            "href": "https://int.crossroads.net/staffcontacts",
             "automation-id": "sh-support-staff-contacts"
           },
           {
             "title": "Ask a Question",
-            "href": "/contactus",
+            "href": "https://int.crossroads.net/contactus",
             "automation-id": "sh-support-ask-a-question"
           },
           {
             "title": "Request Prayer",
-            "href": "/prayer",
+            "href": "https://int.crossroads.net/prayer",
             "automation-id": "sh-support-request-prayer"
           },
           {
             "title": "Jobs",
-            "href": "/jobs",
+            "href": "https://int.crossroads.net/jobs",
             "automation-id": "sh-support-jobs"
           }
         ]
@@ -405,7 +405,7 @@
         },
         {
           "title": "My giving",
-          "href": "/me/giving",
+          "href": "https://int.crossroads.net/me/giving",
           "top_level": true,
           "automation-id": "sh-my-giving"
         }
@@ -414,13 +414,13 @@
       [
         {
           "title": "Why give?",
-          "href": "/giving",
+          "href": "https://int.crossroads.net/giving",
           "top_level": true,
           "automation-id": "sh-why-give"
         },
         {
           "title": "Other ways to give",
-          "href": "/giving/#others",
+          "href": "https://int.crossroads.net/giving/#others",
           "top_level": true,
           "automation-id": "sh-other-ways"
         }
@@ -434,18 +434,18 @@
         {
           "title": "My account",
           "automation-id": "sh-my-accounts",
-          "path": "/profile/personal"
+          "href": "https://int.crossroads.net/profile/personal"
         },
         {
           "title": "Giving",
           "automation-id": "sh-giving",
-          "path": "/me/giving"
+          "href": "https://profile.crossroads.net/giving/history"
         },
         {
           "sign-out": true,
           "title": "Sign out",
           "automation-id": "sh-sign-out",
-          "path": "javascript:void(0)"
+          "href": "javascript:void(0)"
         }
       ],
       "Get Involved",
@@ -453,22 +453,22 @@
         {
           "title": "My student's camps",
           "automation-id": "sh-my-students-camps",
-          "path": "/mycamps"
+          "href": "https://int.crossroads.net/mycamps"
         },
         {
           "title": "Sign up to server",
           "automation-id": "sh-sign-up-to-serve",
-          "path": "/serve/signup"
+          "href": "https://serve.crossroads.net/groups"
         },
         {
           "title": "My groups",
           "automation-id": "sh-my-groups",
-          "path": "/search/my"
+          "href": "https://int.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=At%20Home%20Groups%3D&my=1"
         },
         {
           "title": "My trips",
           "automation-id": "sh-my-trips",
-          "path": "/mytrips"
+          "href": "https://int.crossroads.net/trips/mytrips"
         }
       ],
       "Events",
@@ -476,12 +476,12 @@
         {
           "title": "Event check in",
           "automation-id": "sh-event-check-in",
-          "path": "/events"
+          "href": "https://event-checkin.crossroads.net/events"
         },
         {
           "title": "Childcare (For events)",
           "automation-id": "sh-childcare",
-          "path": "/childcare"
+          "href": "https://int.crossroads.net/childcare"
         }
       ]
     ]

--- a/src/snail-trails/connect/int.json
+++ b/src/snail-trails/connect/int.json
@@ -7,22 +7,22 @@
     ],
     [
       {
-        "href": "https://www.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=At%20Home%20Groups%3D&view=List%20View&my=0",
+        "href": "https://int.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=At%20Home%20Groups%3D&view=List%20View&my=0",
         "data-automation-id": "sh-alt-home-groups",
         "title": "At Home Groups"
       },
       {
-        "href": "https://www.crossroads.net/onsitegroups/",
+        "href": "https://int.crossroads.net/onsitegroups/",
         "data-automation-id": "sh-onsite-groups",
         "title": "Onsite Groups"
       },
       {
-        "href": "https://www.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=Online%20Groups%3D&view=List%20View&my=0",
+        "href": "https://int.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=Online%20Groups%3D&view=List%20View&my=0",
         "data-automation-id": "sh-online-groups",
         "title": "Online Groups"
       },
       {
-        "href": "https://www.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=People%20Near%20Me%3D&view=Map%20View&my=0",
+        "href": "https://int.crossroads.net/connect/?lat=39&lng=-84.51&zoom=9&filters=People%20Near%20Me%3D&view=Map%20View&my=0",
         "data-automation-id": "sh-people-near-me",
         "title": "People Near Me"
       }

--- a/src/snail-trails/media/int.json
+++ b/src/snail-trails/media/int.json
@@ -7,61 +7,61 @@
     ],
     [
       {
-        "href": "https://www.crossroads.net/media",
+        "href": "https://int.crossroads.net/media",
         "data-automation-id": "sh-all-media",
         "title": "All Media"
       }
     ],
     [
       {
-        "href": "https://www.crossroads.net/media/topics/culture",
+        "href": "https://int.crossroads.net/media/topics/culture",
         "data-automation-id": "sh-culture",
         "title": "Culture"
       },
       {
-        "href": "https://www.crossroads.net/media/topics/self",
+        "href": "https://int.crossroads.net/media/topics/self",
         "data-automation-id": "sh-self",
         "title": "Self"
       },
       {
-        "href": "https://www.crossroads.net/media/topics/work",
+        "href": "https://int.crossroads.net/media/topics/work",
         "data-automation-id": "sh-work",
         "title": "Work"
       },
       {
-        "href": "https://www.crossroads.net/media/topics/money",
+        "href": "https://int.crossroads.net/media/topics/money",
         "data-automation-id": "sh-money",
         "title": "Money"
       },
       {
-        "href": "https://www.crossroads.net/media/topics/relationships",
+        "href": "https://int.crossroads.net/media/topics/relationships",
         "data-automation-id": "sh-relationships",
         "title": "Relationships"
       }
     ],
     [
       {
-        "href": "https://www.crossroads.net/media/articles",
+        "href": "https://int.crossroads.net/media/articles",
         "data-automation-id": "sh-articles",
         "title": "Articles"
       },
       {
-        "href": "https://www.crossroads.net/media/music",
+        "href": "https://int.crossroads.net/media/music",
         "data-automation-id": "sh-music",
         "title": "Music"
       },
       {
-        "href": "https://www.crossroads.net/media/podcasts",
+        "href": "https://int.crossroads.net/media/podcasts",
         "data-automation-id": "sh-podcasts",
         "title": "Podcasts"
       },
       {
-        "href": "https://www.crossroads.net/media/series",
+        "href": "https://int.crossroads.net/media/series",
         "data-automation-id": "sh-series",
         "title": "Series"
       },
       {
-        "href": "https://www.crossroads.net/media/videos",
+        "href": "https://int.crossroads.net/media/videos",
         "data-automation-id": "sh-videos",
         "title": "Videos"
       }

--- a/src/snail-trails/trending/int.json
+++ b/src/snail-trails/trending/int.json
@@ -7,27 +7,27 @@
     ],
     [
       {
-        "href": "https://www.crossroads.net/groups/",
+        "href": "https://int.crossroads.net/groups/",
         "data-automation-id": "sh-groups",
         "title": "Groups"
       },
       {
-        "href": "https://www.crossroads.net/camps/",
+        "href": "https://int.crossroads.net/camps/",
         "data-automation-id": "sh-camps",
         "title": "Camps"
       },
       {
-        "href": "https://www.crossroads.net/media/series/how-it-ends-spoiler-its-amazing/how-it-ends-week-2-real-justice",
+        "href": "https://int.crossroads.net/media/series/how-it-ends-spoiler-its-amazing/how-it-ends-week-2-real-justice",
         "data-automation-id": "sh-recent-messages",
         "title": "Recent Messages"
       },
       {
-        "href": "https://www.crossroads.net/undivided/",
+        "href": "https://int.crossroads.net/undivided/",
         "data-automation-id": "sh-undivided",
         "title": "Undivided"
       },
       {
-        "href": "https://www.crossroads.net/connect",
+        "href": "https://int.crossroads.net/connect",
         "data-automation-id": "sh-connect-with-people-in-your-area",
         "title": "Connect with people in your area"
       }


### PR DESCRIPTION
	- Adds paths from sh-prod to sh-int and prepends 'int'
	- Prepends 'int' to all int.json paths

        [This is also part of the solution](https://github.com/crdschurch/crds-net/pull/958)
