### PR TITLE
[automation] Renamed duplicate automation ids

### DIFF
--- a/src/shared-header/demo.json
+++ b/src/shared-header/demo.json
@@ -226,7 +226,7 @@
           {
             "title": "Florence",
             "href": "https://demo.crossroads.net/florence",
-            "automation-id": "sh-location-east-side"
+            "automation-id": "sh-location-florence"
           },
           {
             "title": "Mason",
@@ -345,7 +345,7 @@
           {
             "title": "Prayer",
             "href": "https://demo.crossroads.net/prayer",
-            "automation-id": "sh-support-counselors"
+            "automation-id": "sh-support-prayer"
           }
         ],
         "Life Events",

--- a/src/shared-header/int.json
+++ b/src/shared-header/int.json
@@ -226,7 +226,7 @@
           {
             "title": "Florence",
             "href": "https://int.crossroads.net/florence",
-            "automation-id": "sh-location-east-side"
+            "automation-id": "sh-location-florence"
           },
           {
             "title": "Mason",
@@ -345,7 +345,7 @@
           {
             "title": "Prayer",
             "href": "https://int.crossroads.net/prayer",
-            "automation-id": "sh-support-counselors"
+            "automation-id": "sh-support-prayer"
           }
         ],
         "Life Events",

--- a/src/shared-header/prod.json
+++ b/src/shared-header/prod.json
@@ -226,7 +226,7 @@
           {
             "title": "Florence",
             "href": "https://www.crossroads.net/florence",
-            "automation-id": "sh-location-east-side"
+            "automation-id": "sh-location-florence"
           },
           {
             "title": "Mason",
@@ -345,7 +345,7 @@
           {
             "title": "Prayer",
             "href": "https://www.crossroads.net/prayer",
-            "automation-id": "sh-support-counselors"
+            "automation-id": "sh-support-prayer"
           }
         ],
         "Life Events",


### PR DESCRIPTION
- Made the automation-ids for the Florence and Prayer links in the shared header unique. Applied to int, demo & prod json.